### PR TITLE
security: issue a warning when credential are exposed due to plain http ...

### DIFF
--- a/lib/JIRA/Client/Automated.pm
+++ b/lib/JIRA/Client/Automated.pm
@@ -124,6 +124,9 @@ sub new {
     $auth_url =~ s{//}{/}g;
     $auth_url =~ s{:/}{://};
 
+    if ($auth_url =~ m|http://|) {
+        warn "URL for JIRA should use https to avoid exposing user password in Internet";
+    }
     if ($auth_url !~ m|https?://|) {
         die "URL for JIRA must be absolute, including 'http://' or 'https://'.";
     }


### PR DESCRIPTION
...URL

This may not be important when using a JIRA server in a secure network, On the other hand, using https is important when connecting to Atlassian's server as a http request will expose credential to any snooper.

If needed, a `-quiet` option can be added to silence this warning, but I think the default behavior should encourage security.

All the best 
