### PR TITLE
fix make_browse_url to work with /rest/api in url

### DIFF
--- a/lib/JIRA/Client/Automated.pm
+++ b/lib/JIRA/Client/Automated.pm
@@ -925,7 +925,10 @@ on it and go directly to that issue.
 sub make_browse_url {
     my ($self, $key) = @_;
     # use url + browse + key to synthesize URL
-    return $self->{url} . 'browse/' . $key;
+    my $url = $self->{url};
+    $url =~ s/\/rest\/api\/.*//;
+    $url .= '/' unless $url =~ m{/$};
+    return $url . 'browse/' . $key;
 }
 
 =head2 get_link_types

--- a/t/jira-client-automated.t
+++ b/t/jira-client-automated.t
@@ -66,6 +66,11 @@ END_SKIP_TEXT
     is($issue->{fields}{summary},     "$JCA Test Script",                           'create_issue summary');
     is($issue->{fields}{description}, "Created by $JCA Test Script automatically.", 'create_issue description');
     is($issue->{fields}{labels}[0],   "Commentary",                                 'create_issue labels');
+    {
+        my $browse_url = $jira->make_browse_url($key);
+        ok(($browse_url =~ m{browse/$key$} and $browse_url !~ m{rest/api}),
+            "make_browse_url");
+    }
 
     # Comment on an issue
     my ($comments);


### PR DESCRIPTION
While the new() method accepts url like http://foo.com/jira/rest/api/some_version, in this case make_browse_url() can have problem. The patch is to fix this issue. 